### PR TITLE
increase width for sidebar and article content, remove center align

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -264,6 +264,10 @@ input[name='theme-toggle'] {
   z-index: -1;
 }
 
+nav {
+  width: 65%;
+}
+
 nav .heading {
   font-weight: 400;
   font-size: 1.25rem;

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -118,12 +118,11 @@ editHref = `https://github.com/snowpackjs/astro/tree/main/examples/doc/src/pages
         grid-column: 2;
         display: flex;
         flex-direction: column;
-        align-items: center;
         height: 100%;
       }
 
       .content {
-        max-width: 64ch;
+        max-width: 75ch;
         width: 100%;
         height: 100%;
         display: flex;


### PR DESCRIPTION
Compare the PR preview to the main branch's preview to see the styling changes.

Changes made:
- Increase sidebar width
- Increase article content width
- Remove `align-items: center` from article content

I made modifications to this because I felt the content seemed a bit "smushed" together and it was a bit cramped.