### PR TITLE
Improve usage of links

### DIFF
--- a/src/pages/core-concepts/astro-pages.md
+++ b/src/pages/core-concepts/astro-pages.md
@@ -3,9 +3,9 @@ layout: ~/layouts/Main.astro
 title: Astro Pages
 ---
 
-**Pages** are a special type of [Astro Component](./astro-components) that handle routing, data loading, and templating for each page of your website. You can think of them like any other Astro component, just with extra responsibilities.
+**Pages** are a special type of [Astro Component](/core-concepts/astro-components) that handle routing, data loading, and templating for each page of your website. You can think of them like any other Astro component, just with extra responsibilities.
 
-Astro also supports Markdown for content-heavy pages, like blog posts and documentation. See [Markdown Content](../guides/markdown-content) for more information on writing pages with Markdown. 
+Astro also supports Markdown for content-heavy pages, like blog posts and documentation. See [Markdown Content](/guides/markdown-content) for more information on writing pages with Markdown. 
 
 ## File-based Routing
 

--- a/src/pages/core-concepts/astro-pages.md
+++ b/src/pages/core-concepts/astro-pages.md
@@ -5,7 +5,7 @@ title: Astro Pages
 
 **Pages** are a special type of [Astro Component](./astro-components) that handle routing, data loading, and templating for each page of your website. You can think of them like any other Astro component, just with extra responsibilities.
 
-Astro also supports Markdown for content-heavy pages, like blog posts and documentation. See [Markdown Content](./markdown-content.md) for more information on writing pages with Markdown. 
+Astro also supports Markdown for content-heavy pages, like blog posts and documentation. See [Markdown Content](../guides/markdown-content) for more information on writing pages with Markdown. 
 
 ## File-based Routing
 

--- a/src/pages/core-concepts/collections.md
+++ b/src/pages/core-concepts/collections.md
@@ -29,7 +29,7 @@ To create a new Astro Collection, you must do three things:
 3. Define and export `createCollection` function: this tells Astro how to load and structure your collection data. Check out the examples below for documentation on how it should be implemented. It MUST be named `createCollection` and it must be exported.
 
 - Example: `export async function createCollection() { /* ... */ }`
-- API Reference: [createCollection][collection-api]
+- API Reference: [createCollection](/reference/api-reference#collections-api)
 
 ## Example: Simple Pagination
 
@@ -201,12 +201,8 @@ export async function createCollection() {
 
 ### 📚 Further Reading
 
-- [Fetching data in Astro][docs-data]
-- API Reference: [collection][collection-api]
-- API Reference: [createCollection()][create-collection-api]
-- API Reference: [Creating an RSS feed][creating-an-rss-feed]
+- [Fetching data in Astro](/guides/data-fetching)
+- API Reference: [collection](/reference/api-reference#collections-api)
+- API Reference: [createCollection()](/reference/api-reference#createcollection)
+- API Reference: [Creating an RSS feed](/reference/api-reference#rss-feed)
 
-[docs-data]: /guides/data-fetching
-[collection-api]: /reference/api-reference#collections-api
-[create-collection-api]: /reference/api-reference#createcollection
-[creating-an-rss-feed]: /reference/api-reference#rss-feed

--- a/src/pages/core-concepts/collections.md
+++ b/src/pages/core-concepts/collections.md
@@ -204,8 +204,9 @@ export async function createCollection() {
 - [Fetching data in Astro][docs-data]
 - API Reference: [collection][collection-api]
 - API Reference: [createCollection()][create-collection-api]
-- API Reference: [Creating an RSS feed][create-collection-api]
+- API Reference: [Creating an RSS feed][creating-an-rss-feed]
 
-[docs-data]: ../README.md#-fetching-data
-[collection-api]: ./api.md#collection
-[create-collection-api]: ./api.md#createcollection
+[docs-data]: ../guides/data-fetching
+[collection-api]: ../reference/api-reference#collections-api
+[create-collection-api]: ../reference/api-reference#createcollection
+[creating-an-rss-feed]: ../reference/api-reference#rss-feed

--- a/src/pages/core-concepts/collections.md
+++ b/src/pages/core-concepts/collections.md
@@ -209,5 +209,3 @@ export async function createCollection() {
 [docs-data]: ../README.md#-fetching-data
 [collection-api]: ./api.md#collection
 [create-collection-api]: ./api.md#createcollection
-[example-blog]: ../examples/blog
-[fetch-content]: ./api.md#fetchcontent

--- a/src/pages/core-concepts/collections.md
+++ b/src/pages/core-concepts/collections.md
@@ -3,7 +3,7 @@ layout: ~/layouts/Main.astro
 title: Collections
 ---
 
-**Collections** are a special type of [Page](./astro-pages) that help you generate multiple pages from a larger set of data. Example use-cases include:
+**Collections** are a special type of [Page](/core-concepts/astro-pages) that help you generate multiple pages from a larger set of data. Example use-cases include:
 
 - Pagination: `/posts/1`, `/posts/2`, etc.
 - Grouping content by author: `/author/fred`, `/author/matthew`, etc.
@@ -206,7 +206,7 @@ export async function createCollection() {
 - API Reference: [createCollection()][create-collection-api]
 - API Reference: [Creating an RSS feed][creating-an-rss-feed]
 
-[docs-data]: ../guides/data-fetching
-[collection-api]: ../reference/api-reference#collections-api
-[create-collection-api]: ../reference/api-reference#createcollection
-[creating-an-rss-feed]: ../reference/api-reference#rss-feed
+[docs-data]: /guides/data-fetching
+[collection-api]: /reference/api-reference#collections-api
+[create-collection-api]: /reference/api-reference#createcollection
+[creating-an-rss-feed]: /reference/api-reference#rss-feed

--- a/src/pages/core-concepts/layouts.md
+++ b/src/pages/core-concepts/layouts.md
@@ -3,7 +3,7 @@ layout: ~/layouts/Main.astro
 title: Layouts
 ---
 
-**Layouts** are a special type of [Component](./astro-components) that help you share and reuse common page layouts within your project. 
+**Layouts** are a special type of [Component](/core-concepts/astro-components) that help you share and reuse common page layouts within your project. 
 
 Layouts are just like any other reusable Astro component. There's no new syntax or APIs to learn. However, reusable page layouts are such a common pattern in web development that we created this guide to help you use them.
 

--- a/src/pages/core-concepts/ui-renderers.md
+++ b/src/pages/core-concepts/ui-renderers.md
@@ -198,5 +198,3 @@ export default (element) => {
   };
 };
 ```
-
-[astro-config]: ./config.md

--- a/src/pages/guides/styling.md
+++ b/src/pages/guides/styling.md
@@ -480,7 +480,7 @@ This guide wouldn’t be possible without the following blog posts, which expand
 
 Also please check out the [Stylelint][stylelint] project to whip your styles into shape. You lint your JS, why not your CSS?
 
-[astro-components]: ../core-concepts/astro-components
+[astro-components]: /core-concepts/astro-components
 [autoprefixer]: https://github.com/postcss/autoprefixer
 [bem]: http://getbem.com/introduction/
 [box-model]: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model

--- a/src/pages/guides/styling.md
+++ b/src/pages/guides/styling.md
@@ -154,7 +154,7 @@ _Note: be mindful when some page styles get extracted to the ”common” bundle
 
 Too many development setups take a hands-off approach to CSS, or at most leave you with only contrived examples that don’t get you very far. Telling developers “Use whatever styling solution you want!” is a nice thought that rarely works out in practice. Few styling approaches lend themselves to every setup. Astro is no different—certain styling approaches _will_ work better than others.
 
-An example to illustrate this: Astro removes runtime JS (even the core framework if possible). Thus, depending on Styled Components for all your styles would be bad, as that would require React to load on pages where it’s not needed. Or at best, you’d get a “[FOUC][fouc]” as your static HTML is served but the user waits for JavaScript to download and execute. Or consider a second example at the opposite end of the spectrum: _BEM_. You _can_ use a completely-decoupled [BEM][bem] or [SMACSS][smacss] approach in Astro. But that’s a lot of manual maintenance you can avoid, and it leaves out a lof of convenience of [Astro components][astro-syntax].
+An example to illustrate this: Astro removes runtime JS (even the core framework if possible). Thus, depending on Styled Components for all your styles would be bad, as that would require React to load on pages where it’s not needed. Or at best, you’d get a “[FOUC][fouc]” as your static HTML is served but the user waits for JavaScript to download and execute. Or consider a second example at the opposite end of the spectrum: _BEM_. You _can_ use a completely-decoupled [BEM][bem] or [SMACSS][smacss] approach in Astro. But that’s a lot of manual maintenance you can avoid, and it leaves out a lof of convenience of [Astro components][astro-components].
 
 We think there’s a great middle ground between intuitive-but-slow CSS-in-JS and fast-but-cumbersome global CSS: **Hybrid Scoped + Utility CSS**. This approach works well in Astro, is performant for users, and will be the best styling solution in Astro _for most people_ (provided you’re willing to learn a little). So as a quick recap:
 
@@ -480,7 +480,7 @@ This guide wouldn’t be possible without the following blog posts, which expand
 
 Also please check out the [Stylelint][stylelint] project to whip your styles into shape. You lint your JS, why not your CSS?
 
-[astro-syntax]: ./syntax.md
+[astro-components]: ../core-concepts/astro-components
 [autoprefixer]: https://github.com/postcss/autoprefixer
 [bem]: http://getbem.com/introduction/
 [box-model]: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model

--- a/src/pages/guides/styling.md
+++ b/src/pages/guides/styling.md
@@ -154,7 +154,7 @@ _Note: be mindful when some page styles get extracted to the ”common” bundle
 
 Too many development setups take a hands-off approach to CSS, or at most leave you with only contrived examples that don’t get you very far. Telling developers “Use whatever styling solution you want!” is a nice thought that rarely works out in practice. Few styling approaches lend themselves to every setup. Astro is no different—certain styling approaches _will_ work better than others.
 
-An example to illustrate this: Astro removes runtime JS (even the core framework if possible). Thus, depending on Styled Components for all your styles would be bad, as that would require React to load on pages where it’s not needed. Or at best, you’d get a “[FOUC][fouc]” as your static HTML is served but the user waits for JavaScript to download and execute. Or consider a second example at the opposite end of the spectrum: _BEM_. You _can_ use a completely-decoupled [BEM][bem] or [SMACSS][smacss] approach in Astro. But that’s a lot of manual maintenance you can avoid, and it leaves out a lof of convenience of [Astro components][astro-components].
+An example to illustrate this: Astro removes runtime JS (even the core framework if possible). Thus, depending on Styled Components for all your styles would be bad, as that would require React to load on pages where it’s not needed. Or at best, you’d get a “[FOUC][fouc]” as your static HTML is served but the user waits for JavaScript to download and execute. Or consider a second example at the opposite end of the spectrum: _BEM_. You _can_ use a completely-decoupled [BEM][bem] or [SMACSS][smacss] approach in Astro. But that’s a lot of manual maintenance you can avoid, and it leaves out a lof of convenience of [Astro components](/core-concepts/astro-components).
 
 We think there’s a great middle ground between intuitive-but-slow CSS-in-JS and fast-but-cumbersome global CSS: **Hybrid Scoped + Utility CSS**. This approach works well in Astro, is performant for users, and will be the best styling solution in Astro _for most people_ (provided you’re willing to learn a little). So as a quick recap:
 
@@ -480,7 +480,6 @@ This guide wouldn’t be possible without the following blog posts, which expand
 
 Also please check out the [Stylelint][stylelint] project to whip your styles into shape. You lint your JS, why not your CSS?
 
-[astro-components]: /core-concepts/astro-components
 [autoprefixer]: https://github.com/postcss/autoprefixer
 [bem]: http://getbem.com/introduction/
 [box-model]: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model

--- a/src/pages/reference/api-reference.md
+++ b/src/pages/reference/api-reference.md
@@ -175,7 +175,6 @@ export default function () {
 ```
 
 [canonical]: https://en.wikipedia.org/wiki/Canonical_link_element
-[config]: ../README.md#%EF%B8%8F-configuration
 [docs-collections]: ./collections.md
 [rss]: #-rss-feed
 

--- a/src/pages/reference/api-reference.md
+++ b/src/pages/reference/api-reference.md
@@ -9,7 +9,7 @@ The `Astro` global is available in all contexts in `.astro` files. It has the fo
 
 ### `Astro.fetchContent()`
 
-`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup. You can either use this on its own, or within [Astro Collections][docs-collections].
+`Astro.fetchContent()` is a way to load local `*.md` files into your static site setup. You can either use this on its own, or within [Astro Collections](/core-concepts/collections).
 
 ```jsx
 // ./src/components/my-component.astro
@@ -70,7 +70,7 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
 const { collection } = Astro.props;
 ```
 
-When using the [Collections API][docs-collections], `collection` is a prop exposed to the page with the following shape:
+When using the [Collections API](/core-concepts/collections), `collection` is a prop exposed to the page with the following shape:
 
 | Name                      |         Type          | Description                                                                                                                       |
 | :------------------------ | :-------------------: | :-------------------------------------------------------------------------------------------------------------------------------- |
@@ -101,15 +101,15 @@ export async function createCollection() {
 }
 ```
 
-When using the [Collections API][docs-collections], `createCollection()` is an async function that returns an object of the following shape:
+When using the [Collections API](/core-concepts/collections), `createCollection()` is an async function that returns an object of the following shape:
 
-| Name        |             Type              | Description                                                                                                |
-| :---------- | :---------------------------: | :--------------------------------------------------------------------------------------------------------- |
-| `data`      | `async ({ params }) => any[]` | **Required.** Load an array of data with this function to be returned.                                     |
-| `pageSize`  |           `number`            | Specify number of items per page (default: `25`).                                                          |
-| `routes`    |          `params[]`           | **Required for URL Params.** Return an array of all possible URL `param` values in `{ name: value }` form. |
-| `permalink` |   `({ params }) => string`    | **Required for URL Params.** Given a `param` object of `{ name: value }`, generate the final URL.\*        |
-| `rss`       |          [RSS][rss]           | Optional: generate an RSS 2.0 feed from this collection ([docs][rss]).                                     |
+| Name        |                   Type                   | Description                                                                                                |
+| :---------- | :--------------------------------------: | :--------------------------------------------------------------------------------------------------------- |
+| `data`      |      `async ({ params }) => any[]`       | **Required.** Load an array of data with this function to be returned.                                     |
+| `pageSize`  |                 `number`                 | Specify number of items per page (default: `25`).                                                          |
+| `routes`    |                `params[]`                | **Required for URL Params.** Return an array of all possible URL `param` values in `{ name: value }` form. |
+| `permalink` |         `({ params }) => string`         | **Required for URL Params.** Given a `param` object of `{ name: value }`, generate the final URL.\*        |
+| `rss`       | [RSS](/reference/api-reference#rss-feed) | Optional: generate an RSS 2.0 feed from this collection ([docs](/reference/api-reference#rss-feed))        |
 
 _\* Note: don’t create confusing URLs with `permalink`, e.g. rearranging params conditionally based on their values._
 
@@ -175,6 +175,4 @@ export default function () {
 ```
 
 [canonical]: https://en.wikipedia.org/wiki/Canonical_link_element
-[docs-collections]: /core-concepts/collections
-[rss]: /reference/api-reference#rss-feed
 

--- a/src/pages/reference/api-reference.md
+++ b/src/pages/reference/api-reference.md
@@ -175,6 +175,6 @@ export default function () {
 ```
 
 [canonical]: https://en.wikipedia.org/wiki/Canonical_link_element
-[docs-collections]: ../core-concepts/collections
-[rss]: #rss-feed
+[docs-collections]: /core-concepts/collections
+[rss]: /reference/api-reference#rss-feed
 

--- a/src/pages/reference/api-reference.md
+++ b/src/pages/reference/api-reference.md
@@ -175,6 +175,6 @@ export default function () {
 ```
 
 [canonical]: https://en.wikipedia.org/wiki/Canonical_link_element
-[docs-collections]: ./collections.md
-[rss]: #-rss-feed
+[docs-collections]: ../core-concepts/collections
+[rss]: #rss-feed
 

--- a/src/pages/reference/cli-reference.md
+++ b/src/pages/reference/cli-reference.md
@@ -7,7 +7,7 @@ title: CLI Reference
 
 ### `astro dev`
 
-Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or which folder is specified in your [configuration](../README.md##%EF%B8%8F-configuration)).
+Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or which folder is specified in your [configuration](./configuration-reference)).
 
 See the [dev server](./dev.md) docs for more information on how the dev server works.
 

--- a/src/pages/reference/cli-reference.md
+++ b/src/pages/reference/cli-reference.md
@@ -7,7 +7,7 @@ title: CLI Reference
 
 ### `astro dev`
 
-Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or which folder is specified in your [configuration](./configuration-reference)).
+Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or which folder is specified in your [configuration](/reference/configuration-reference)).
 
 See the [dev server](./dev.md) docs for more information on how the dev server works.
 

--- a/src/pages/reference/renderer-reference.md
+++ b/src/pages/reference/renderer-reference.md
@@ -153,5 +153,3 @@ export default (element) => {
   };
 };
 ```
-
-[astro-config]: ./config.md


### PR DESCRIPTION
Hi,

I found broken links in the documentation and fixed them. In addition, I've made a few changes to make it more maintainable.

I also noticed the following (I didn't know how to deal with it, so I left it alone):

- There is no appropriate link for `[dev server](./dev.md)` on `src/pages/reference/cli-reference.md`
- `src/pages/core-concepts/ui-renderers.md` appears to be a stale version of  `src/pages/reference/renderer-reference.md`
