### PR TITLE
Update GitHub Pages deployment guide

### DIFF
--- a/src/pages/guides/deploy.md
+++ b/src/pages/guides/deploy.md
@@ -35,7 +35,8 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
 ## GitHub Pages
 
 1. Set the correct `buildOptions.site` in `astro.config.js`.
-2. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:
+2. Run `touch public/.nojekyll` to create a `.nojekyll` file in `public/`. This [bypasses GitHub Page's default behavior](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/) to ignore paths prefixed with `_`.
+3. Inside your project, create `deploy.sh` with the following content (uncommenting the appropriate lines), and run it to deploy:
 
    ```bash{13,20,23}
    #!/usr/bin/env sh
@@ -65,6 +66,10 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
    cd -
    ```
 > You can also run the above script in your CI setup to enable automatic deployment on each push.
+
+**Note**
+
+
 
 ### GitHub Actions
 

--- a/src/pages/guides/deploy.md
+++ b/src/pages/guides/deploy.md
@@ -67,10 +67,6 @@ By default, the build output will be placed at `dist/`. You may deploy this `dis
    ```
 > You can also run the above script in your CI setup to enable automatic deployment on each push.
 
-**Note**
-
-
-
 ### GitHub Actions
 
 TODO: We'd love an example action snippet to share here!


### PR DESCRIPTION
It turns out that `.nojekyll` is necessary to enable `/_astro/*` URLs, so this adds a note about that.

See https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/