### PR TITLE
Add the basic idea for showing the sidebar on mobile

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -195,8 +195,14 @@ img {
 header button {
   background-color: var(--theme-bg);
 }
+
 header button:hover,
 header button:focus {
+  outline: var(--theme-text) solid 1px;
+}
+
+header button:active,
+header button[aria-pressed='true'] {
   background: var(--theme-text);
   color: var(--theme-bg);
 }
@@ -214,6 +220,7 @@ button {
   align-items: center;
   gap: 0.25em;
   border-radius: 99em;
+  color: var(--theme-text);
   background-color: var(--theme-bg);
 }
 
@@ -325,7 +332,6 @@ h2.heading {
   font-size: 1rem;
 }
 
-
 /* Scrollbar */
 
 /* width */
@@ -355,3 +361,16 @@ h2.heading {
   display: none;
 }
 /* Scrollbar - End */
+
+/* Screenreader Only Text */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/src/components/EditOnGithub.tsx
+++ b/src/components/EditOnGithub.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 
 const EditOnGithub: FunctionalComponent<{ href: string }> = ({ href }) => {
   return (
-    <a className="edit-on-github" href={href}>
+    <a class="edit-on-github" href={href}>
       <svg
         preserveAspectRatio="xMidYMid meet"
         height="1em"

--- a/src/components/EditOnGithub.tsx
+++ b/src/components/EditOnGithub.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 
 const EditOnGithub: FunctionalComponent<{ href: string }> = ({ href }) => {
   return (
-    <a class="edit-on-github" href={href}>
+    <a className="edit-on-github" href={href}>
       <svg
         preserveAspectRatio="xMidYMid meet"
         height="1em"

--- a/src/components/MenuToggle.tsx
+++ b/src/components/MenuToggle.tsx
@@ -16,6 +16,7 @@ const MenuToggle: FunctionalComponent = () => {
 
   return (
     <button
+      type="button"
       aria-pressed={sidebarShown ? 'true' : 'false'}
       id="menu-toggle"
       onClick={() => setSidebarShown(!sidebarShown)}

--- a/src/components/MenuToggle.tsx
+++ b/src/components/MenuToggle.tsx
@@ -6,11 +6,11 @@ const MenuToggle: FunctionalComponent = () => {
   const [sidebarShown, setSidebarShown] = useState(false);
 
   useEffect(() => {
-    const sidebar = document.getElementById('sidebar-nav');
+    const body = document.getElementsByTagName('body')[0];
     if (sidebarShown) {
-      sidebar.classList.remove('hidden');
+      body.classList.remove('mobile-sidebar-hidden');
     } else {
-      sidebar.classList.add('hidden');
+      body.classList.add('mobile-sidebar-hidden');
     }
   }, [sidebarShown]);
 

--- a/src/components/MenuToggle.tsx
+++ b/src/components/MenuToggle.tsx
@@ -1,0 +1,43 @@
+import type { FunctionalComponent } from 'preact';
+import { h, Fragment } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+
+const MenuToggle: FunctionalComponent = () => {
+  const [sidebarShown, setSidebarShown] = useState(false);
+
+  useEffect(() => {
+    const sidebar = document.getElementById('sidebar-nav');
+    if (sidebarShown) {
+      sidebar.classList.remove('hidden');
+    } else {
+      sidebar.classList.add('hidden');
+    }
+  }, [sidebarShown]);
+
+  return (
+    <button
+      aria-pressed={sidebarShown ? 'true' : 'false'}
+      id="menu-toggle"
+      onClick={() => setSidebarShown(!sidebarShown)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        />
+      </svg>
+      <span className="sr-only">Toggle sidebar</span>
+    </button>
+  );
+};
+
+export default MenuToggle;

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -216,7 +216,7 @@ const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${curr
     </header>
 
     <main class="layout">
-      <aside class="sidebar.hidden" id="sidebar-site">
+      <aside class="sidebar" id="sidebar-site">
         <SiteSidebar currentPage={currentPage.slice(1)} />
       </aside>
       <div id="article">

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -3,12 +3,13 @@ import ArticleFooter from '../components/ArticleFooter.astro';
 import SiteSidebar from '../components/SiteSidebar.astro';
 import ThemeToggle from '../components/ThemeToggle.tsx';
 import DocSidebar from '../components/DocSidebar.tsx';
+import MenuToggle from '../components/MenuToggle.tsx';
 
 const { content } = Astro.props;
 const headers = content?.astro?.headers;
 const currentPage = Astro.request.url.pathname;
 const currentFile = currentPage === '/' ? 'src/pages/index.md' : `src/pages${currentPage.replace(/\/$/, "")}.md`;
-const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${currentFile}`
+const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${currentFile}`;
 ---
 
 <html lang="{content.lang ?? 'en-us'}">
@@ -198,11 +199,9 @@ const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${curr
     <header>
       <nav class="nav-wrapper">
         <div class="menu-and-logo flex">
-          <button id="menu-toggle">
-            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </button>
+          <div class="menu-toggle">
+              <MenuToggle:idle/>
+          </div>
           <a id="site-title" href="/">
             <h1>Astro Documentation</h1>
           </a>

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -216,7 +216,7 @@ const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${curr
     </header>
 
     <main class="layout">
-      <aside class="sidebar" id="sidebar-site">
+      <aside class="sidebar.hidden" id="sidebar-site">
         <SiteSidebar currentPage={currentPage.slice(1)} />
       </aside>
       <div id="article">

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -200,7 +200,7 @@ const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${curr
       <nav class="nav-wrapper">
         <div class="menu-and-logo flex">
           <div class="menu-toggle">
-              <MenuToggle:idle/>
+              <MenuToggle client:idle/>
           </div>
           <a id="site-title" href="/">
             <h1>Astro Documentation</h1>


### PR DESCRIPTION
I figure it'd be a good idea to implement the CSS along these lines: https://adrianroselli.com/2021/06/using-css-to-enforce-accessibility.html, though it's a bit messy at the moment, the basic setup is done for making the sidebar navigation visible on mobile, but I haven't figured out the grid and everything.

Also topical: https://inclusive-components.design/menus-menu-buttons/#navigationmenubuttons

Fixes #29 
