### PR TITLE
Link to git blame page in AvatarList

### DIFF
--- a/src/components/AvatarList.astro
+++ b/src/components/AvatarList.astro
@@ -70,6 +70,7 @@ const additionalContributors = unique.length - recentContributors.length; // lis
 ))}
   </ul>
   {additionalContributors > 0 && <span><a href={blameURL}>{`and ${additionalContributors} additional contributor${additionalContributors > 1 ? 's' : ''}.`}</a></span>}
+  {unique.length === 0 && <a href={blameURL}>Contributors</a>}
 </div>
 
 <style>

--- a/src/components/AvatarList.astro
+++ b/src/components/AvatarList.astro
@@ -2,7 +2,7 @@
 // fetch all commits for just this page's path
 const { path } = Astro.props;
 const url = `https://api.github.com/repos/snowpackjs/astro-docs/commits?path=${path}`;
-const blameURL = `https://github.com/snowpackjs/astro-docs/blame/main/${path}`;
+const commitsURL = `https://github.com/snowpackjs/astro-docs/commits/main/${path}`;
 
 async function getCommits(url) {
   try {
@@ -69,8 +69,8 @@ const additionalContributors = unique.length - recentContributors.length; // lis
       
 ))}
   </ul>
-  {additionalContributors > 0 && <span><a href={blameURL}>{`and ${additionalContributors} additional contributor${additionalContributors > 1 ? 's' : ''}.`}</a></span>}
-  {unique.length === 0 && <a href={blameURL}>Contributors</a>}
+  {additionalContributors > 0 && <span><a href={commitsURL}>{`and ${additionalContributors} additional contributor${additionalContributors > 1 ? 's' : ''}.`}</a></span>}
+  {unique.length !== 0 && <a href={commitsURL}>Contributors</a>}
 </div>
 
 <style>

--- a/src/components/AvatarList.astro
+++ b/src/components/AvatarList.astro
@@ -2,6 +2,7 @@
 // fetch all commits for just this page's path
 const { path } = Astro.props;
 const url = `https://api.github.com/repos/snowpackjs/astro-docs/commits?path=${path}`;
+const blameURL = `https://github.com/snowpackjs/astro-docs/blame/main/${path}`;
 
 async function getCommits(url) {
   try {
@@ -68,7 +69,7 @@ const additionalContributors = unique.length - recentContributors.length; // lis
       
 ))}
   </ul>
-  {additionalContributors > 0 && <span>{`and ${additionalContributors} additional contributor${additionalContributors > 1 && 's'}.`}</span>}
+  {additionalContributors > 0 && <span><a href={blameURL}>{`and ${additionalContributors} additional contributor${additionalContributors > 1 ? 's' : ''}.`}</a></span>}
 </div>
 
 <style>


### PR DESCRIPTION
Changes:
- Adds a link to the git blame for the file if there are more than 3 contributors
- Links to the git blame for the file if we weren't able to fetch contributors using the git API, rather than just leaving the spot empty.