### PR TITLE
Fix astro warnings `:directive` -> `client:directive`

### DIFF
--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -205,7 +205,7 @@ const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${curr
         <div />
 
         <div class="theme-toggle-wrapper">
-          <ThemeToggle:idle />
+          <ThemeToggle client:idle />
         </div>
       </nav>
     </header>
@@ -224,7 +224,7 @@ const githubEditUrl = `https://github.com/snowpackjs/astro-docs/blob/main/${curr
         </article>
       </div>
       <aside class="sidebar" id="sidebar-content">
-        <DocSidebar:idle headers={headers} editHref={githubEditUrl} />
+        <DocSidebar client:idle headers={headers} editHref={githubEditUrl} />
       </aside>
     </main>
   </body>

--- a/src/pages/guides/markdown-content.md
+++ b/src/pages/guides/markdown-content.md
@@ -129,11 +129,11 @@ const expressions = 'Lorem ipsum';
     - Rich component support like any `.astro` file!
     - Recursive Markdown support (Component children are also processed as Markdown)
 
-    <MyFancyCodePreview:visible>
+    <MyFancyCodePreview client:visible>
       ```jsx
       const object = { someOtherValue };
       ```
-    </MyFancyCodePreview:visible>
+    </MyFancyCodePreview client:visible>
   </Markdown>
 </Layout>
 ````

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -195,7 +195,7 @@ import ThemeToggle from '../components/ThemeToggle.tsx';
         <div />
 
         <div class="theme-toggle-wrapper">
-          <ThemeToggle:idle />
+          <ThemeToggle client:idle />
         </div>
       </nav>
     </header>


### PR DESCRIPTION
This PR removes the astro warnings for using the old loading directive syntax.