### PR TITLE
Add link the AvatarList.astro component on error.

### DIFF
--- a/src/components/AvatarList.astro
+++ b/src/components/AvatarList.astro
@@ -8,7 +8,7 @@ async function getCommits(url) {
     const token = import.meta.env.SNOWPACK_PUBLIC_GITHUB_TOKEN;
     if (!token) {
       throw new Error(
-        'Cannot find "SNOWPACK_PUBLIC_GITHUB_TOKEN" added for escaping rate-limiting.'
+        'Cannot find "SNOWPACK_PUBLIC_GITHUB_TOKEN" used for escaping rate-limiting.'
       );
     }
 
@@ -33,7 +33,8 @@ async function getCommits(url) {
 
     return data;
   } catch (e) {
-    console.warn(`${e}`);
+    console.warn(`[error]  /src/components/AvatarList.astro 
+    ${e?.message ?? e}`);
     return new Array();
   }
 }


### PR DESCRIPTION
Make the error reporting just a **bit** clearer for `AvatarList.astro` since there's currently no reference to the file to tell you where the error is coming from.

This honestly might be something to add to `astro` by default: prefixing `console.log` in the build with the component it printed from, or at least a custom logger that people can opt in to