### PR TITLE
Fix typo in named slots example

### DIFF
--- a/src/pages/core-concepts/astro-components.md
+++ b/src/pages/core-concepts/astro-components.md
@@ -212,7 +212,7 @@ Slots become even more powerful when using **named slots**. Rather than a single
   </main>
   <footer>
     <!-- children with the `slot="footer"` attribute will go here -->
-    <slot name="footer"> 
+    <slot name="footer" /> 
   </footer>
 </div>
 


### PR DESCRIPTION
The named slots update works great! However, if you paste the example as-is from the docs, it produces an error.

`<slot name="footer">`

Should be corrected to:

`<slot name="footer" />`