### PR TITLE
Add a scroll-margin-top to `:target` so that in-document links scroll…

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -371,3 +371,8 @@ h2.heading {
   white-space: nowrap;
   border-width: 0;
 }
+/* Screenreader Only Text - End */
+
+:target {
+  scroll-margin-top: 4rem;
+}


### PR DESCRIPTION
… past the sticky header.